### PR TITLE
FE-93: Fixes copy issues

### DIFF
--- a/src/copy.ts
+++ b/src/copy.ts
@@ -20,7 +20,16 @@ export default {
     }
   },
   nav: {
-    sections: ["about", "schedule", "judges", "workshops", "sponsors", "prizes", "activities", "faq"],
+    sections: [
+      "about",
+      "schedule",
+      "judges",
+      "workshops",
+      "sponsors",
+      "prizes",
+      "activities",
+      "faq"
+    ],
     socialLinks: [
       {
         name: "facebook",
@@ -42,7 +51,7 @@ export default {
   about: {
     title: "about",
     desc:
-      "Hackioca is the first boba-themed hackathon, where your love for boba and tech intertwine. Immerse yourself in a weekend filled with workshops, and activities at the Taipei 101. Join hackers from all around the globe who share the passion for world-class builds and boba."
+      "Hackioca is the first boba-themed hackathon, where your love for boba and tech intertwine. Immerse yourself in a weekend filled with workshops and activities at the Taipei 101. Join hackers from all around the globe who share a passion for world-class builds and boba!"
   },
   schedule: {
     title: "schedule",
@@ -68,7 +77,7 @@ export default {
         { title: "Activity: Bubble Soccer", time: "2pm-3pm" },
         { title: "Lunch: Burritos and Boba", time: "2pm-3pm" },
         { title: "Snack: Mochi and Boba", time: "3pm-5pm" },
-        { title: "Dinner: Boba w/ Parental Disappointment", time: "6pm-8pm," },
+        { title: "Dinner: Boba w/ Parental Disappointment", time: "6pm-8pm" },
         { title: "Activity: Do hw that’s due tomorrow", time: "10pm-11:30pm" }
       ]
     },


### PR DESCRIPTION
Fixes the following copy issues in the about and schedule sections:
- Extra comma
- Replacing "the" with "a" and extra comma