### PR TITLE
FE-84 & FE-84 : Fix NavLinks order and Social Links

### DIFF
--- a/src/copy.ts
+++ b/src/copy.ts
@@ -25,7 +25,7 @@ export default {
       {
         name: "facebook",
         icon: "facebook.png",
-        link: "https://facebook.com"
+        link: "https://www.facebook.com/hackioca"
       },
       {
         name: "twitter",


### PR DESCRIPTION
correct order is `about, schedule, judges, workshops, activities, sponsors, prizes, faq`. Use actual social links (missing FB link).