### PR TITLE
Add basic IE compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16072,21 +16072,32 @@
       }
     },
     "react-app-polyfill": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.1.3.tgz",
-      "integrity": "sha512-Fl5Pic4F15G05qX7RmUqPZr1MtyFKJKSlRwMhel4kvDLrk/KcQ9QbpvyMTzv/0NN5957XFQ7r1BNHWi7qN59Pw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.2.2.tgz",
+      "integrity": "sha512-mAYn96B/nB6kWG87Ry70F4D4rsycU43VYTj3ZCbKP+SLJXwC0x6YCbwcICh3uW8/C9s1VgP197yx+w7SCWeDdQ==",
+      "dev": true,
       "requires": {
-        "core-js": "2.5.7",
+        "core-js": "2.6.4",
         "object-assign": "4.1.1",
         "promise": "8.0.2",
-        "raf": "3.4.0",
+        "raf": "3.4.1",
         "whatwg-fetch": "3.0.0"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
+          "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==",
+          "dev": true
+        },
+        "raf": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+          "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+          "dev": true,
+          "requires": {
+            "performance-now": "^2.1.0"
+          }
         }
       }
     },
@@ -16434,6 +16445,11 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -16670,6 +16686,18 @@
           "requires": {
             "ansi-regex": "^3.0.0",
             "ansi-styles": "^3.2.0"
+          }
+        },
+        "react-app-polyfill": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.1.3.tgz",
+          "integrity": "sha512-Fl5Pic4F15G05qX7RmUqPZr1MtyFKJKSlRwMhel4kvDLrk/KcQ9QbpvyMTzv/0NN5957XFQ7r1BNHWi7qN59Pw==",
+          "requires": {
+            "core-js": "2.5.7",
+            "object-assign": "4.1.1",
+            "promise": "8.0.2",
+            "raf": "3.4.0",
+            "whatwg-fetch": "3.0.0"
           }
         },
         "source-map-support": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.12.4",
     "prettier": "1.16.4",
+    "react-app-polyfill": "^0.2.2",
     "react-test-renderer": "^16.8.4",
     "stylelint": "^9.10.1",
     "stylelint-config-recommended": "^2.1.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import "react-app-polyfill/ie11"
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./app/App";


### PR DESCRIPTION
Without this, IE wouldn't render at all because of `Object.assign`. This adds basic polyfills. Query params break the site though. I don't think _that_ is worth fixing.