### PR TITLE
Move query params logic to boba context

### DIFF
--- a/src/app/sections/Hero/BobaDisplay.tsx
+++ b/src/app/sections/Hero/BobaDisplay.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import media from "src/utils/media";
-import { toppings, Topping, Flavor } from "src/data";
+import { Flavor } from "src/flavor";
+import { Topping, toppings } from "src/topping";
 import { getScrollbarWidth } from "src/utils/scroll-bar-width";
 import Slider from "react-slick";
 

--- a/src/app/sections/Hero/OptionPicker.tsx
+++ b/src/app/sections/Hero/OptionPicker.tsx
@@ -3,7 +3,8 @@ import styled from "styled-components";
 import media from "src/utils/media";
 
 import ImgChevron from "src/static/images/chevron_up.svg";
-import { Flavor, Topping } from "src/data";
+import { Flavor } from "src/flavor";
+import { Topping } from "src/topping";
 
 import ImgToppingOptionGrassJelly from "src/static/images/hero/options/toppings/grass_jelly.svg";
 import ImgToppingOptionTapioca from "src/static/images/hero/options/toppings/tapioca.svg";

--- a/src/flavor.ts
+++ b/src/flavor.ts
@@ -1,0 +1,13 @@
+export type Flavor = "strawberry" | "mango" | "milk" | "matcha" | "taro";
+
+export const flavors: ReadonlyArray<Flavor> = [
+  "milk",
+  "matcha",
+  "taro",
+  "mango",
+  "strawberry"
+];
+
+export const isFlavor = (flavor: unknown): flavor is Flavor => {
+  return typeof flavor === "string" && flavors.indexOf(flavor as Flavor) >= 0;
+}

--- a/src/topping.ts
+++ b/src/topping.ts
@@ -1,18 +1,10 @@
-export type Flavor = "strawberry" | "mango" | "milk" | "matcha" | "taro";
-export const flavors: ReadonlyArray<Flavor> = [
-  "milk",
-  "matcha",
-  "taro",
-  "mango",
-  "strawberry"
-];
-
 export type Topping =
   | "tapioca"
   | "grass_jelly"
   | "aloe_vera"
   | "red_bean"
   | "pudding";
+
 export const toppings: ReadonlyArray<Topping> = [
   "tapioca",
   "grass_jelly",
@@ -20,3 +12,7 @@ export const toppings: ReadonlyArray<Topping> = [
   "red_bean",
   "pudding"
 ];
+
+export const isTopping = (topping: unknown): topping is Topping => {
+  return typeof topping === "string" && toppings.indexOf(topping as Topping) >= 0;
+}

--- a/src/utils/context/boba.tsx
+++ b/src/utils/context/boba.tsx
@@ -1,11 +1,13 @@
 import React, { useState, createContext, useContext } from "react";
-import { Flavor, Topping, flavors, toppings } from "src/data";
+import { useQueryParam, StringParam } from 'use-query-params';
+import { Flavor, isFlavor, flavors } from 'src/flavor';
+import { Topping, isTopping, toppings } from 'src/topping';
 
 export interface BobaState {
   flavor: Flavor;
   topping: Topping;
-  updateFlavor: (newFlavor: Flavor) => void;
-  updateTopping: (newTopping: Topping) => void;
+  updateFlavor: (newFlavor: Flavor, updateQueryParam?: boolean) => void;
+  updateTopping: (newTopping: Topping, updateQueryParam?: boolean) => void;
 }
 
 export const BobaContext: React.Context<BobaState> = createContext({
@@ -20,11 +22,31 @@ export const useBobaContext = () => useContext(BobaContext);
 const randomFlavor = flavors[Math.floor(Math.random() * flavors.length)];
 const randomTopping = toppings[Math.floor(Math.random() * toppings.length)];
 
-export const BobaProvider: React.FC<{ children: React.ReactNode }> = ({
+export const BobaProvider: React.FC= ({
   children
 }) => {
-  const [flavor, updateFlavor] = useState(randomFlavor);
-  const [topping, updateTopping] = useState(randomTopping);
+  const [stateFlavor, updateStateFlavor] = useState<Flavor>();
+  const [stateTopping, updateStateTopping] = useState<Topping>();
+
+  const [queryParamFlavor, updateQueryParamFlavor] = useQueryParam("flavor", StringParam);
+  const [queryParamTopping, updateQueryParamTopping] = useQueryParam("topping", StringParam);
+
+  const flavor: Flavor = stateFlavor || (isFlavor(queryParamFlavor) ? queryParamFlavor : randomFlavor);
+  const topping: Topping = stateTopping || (isTopping(queryParamTopping) ? queryParamTopping : randomTopping);
+
+  const updateFlavor = (newFlavor: Flavor, updateQueryParam: boolean = true): void => {
+    updateStateFlavor(newFlavor);
+    if (updateQueryParam) {
+      updateQueryParamFlavor(newFlavor);
+    }
+  }
+
+  const updateTopping = (newTopping: Topping, updateQueryParam: boolean = true): void => {
+    updateStateTopping(newTopping);
+    if (updateQueryParam) {
+      updateQueryParamTopping(newTopping);
+    }
+  }
 
   const bobaState: BobaState = {
     flavor,


### PR DESCRIPTION
This abstracts the logic of updating the query params from the hero components and into the boba context. If another component would also need to update the toppings/flavors, it wouldn't have to worry about updating the url itself.

Another cool feature is that now the 404 page background is customized to what flavor you have in the url.

This should behave exactly as before, the one change though is that if your url is `https://hackioca.com` and then you click on a flavor, the url will become `https://hackioca.com?flavor=mango` as opposed to `https://hackioca.com?flavor=mango&topping=TOPPING` which imo is kinda nice because then if they refresh, they'll still get a random topping since they didn't actually pick one.